### PR TITLE
RELOAD-182

### DIFF
--- a/ReloadClient/LoginScreen.cpp
+++ b/ReloadClient/LoginScreen.cpp
@@ -140,10 +140,6 @@ void LoginScreen::rebuildScreenLayout(int screenWidth, int screenHeight, MAUtil:
 {
 	// on wp7 the layout changes look glitchy so we'll set the layout after all the
 	// repositioning has been done
-	if(mOS.find("Windows", 0) >= 0)
-	{
-	//	mLoginScreen->setMainWidget(NULL);
-	}
 
 	mMainLayout->setSize(screenWidth, screenHeight);
 	mBackground->setSize(screenWidth, screenHeight);
@@ -209,11 +205,6 @@ void LoginScreen::rebuildScreenLayout(int screenWidth, int screenHeight, MAUtil:
 				LOGO_SCREEN_HEIGHT_PORTRAIT_RATIO,
 				LOGO_TOP_PORTRAIT_RATIO,
 				LOGO_WIDTH_PORTRAIT_RATIO);
-	}
-
-	if(mOS.find("Windows", 0) >= 0)
-	{
-	//	mLoginScreen->setMainWidget(mMainLayout);
 	}
 }
 
@@ -659,5 +650,16 @@ void LoginScreen::defaultAddress(const char *serverAddress)
  */
 void LoginScreen::orientationChanged(int newOrientation, int newScreenWidth, int newScreenHeight)
 {
+	// on wp7 the screen size on landscape has the same values as portrait
+	// so we need to swap those values
+	if ((newOrientation == MA_SCREEN_ORIENTATION_LANDSCAPE_LEFT ||
+			newOrientation == MA_SCREEN_ORIENTATION_LANDSCAPE_RIGHT) &&
+			mOS.find("Windows", 0) >= 0)
+	{
+		int aux = newScreenWidth;
+		newScreenWidth = newScreenHeight;
+		newScreenHeight = aux;
+	}
+
 	rebuildScreenLayout(newScreenWidth, newScreenHeight, mOS, newOrientation);
 }

--- a/ReloadClient/LoginScreenWidget.cpp
+++ b/ReloadClient/LoginScreenWidget.cpp
@@ -68,14 +68,6 @@ void LoginScreenWidget::orientationDidChange()
 	int screenWidth = EXTENT_X(ex);
 	int screenHeight = EXTENT_Y(ex);
 
-	if (orientation == MA_SCREEN_ORIENTATION_LANDSCAPE_LEFT ||
-			orientation == MA_SCREEN_ORIENTATION_LANDSCAPE_RIGHT)
-	{
-		int aux = screenWidth;
-		screenWidth = screenHeight;
-		screenHeight = aux;
-	}
-
 	// announce the screen listeners if the orientation has changed
 	for (int i = 0; i < mLoginScreenListeners.size(); i++)
 	{


### PR DESCRIPTION
on iOS the screen height/width is now sent correctly (according to the orientation). On wp7, the values are the same (disregarding the orientation)
so we need to manually  swap them.
