### PR TITLE
RELOAD-365

### DIFF
--- a/ReloadAppTemplates/MoSync_Reload_Windows/ReloadLauncher.bat
+++ b/ReloadAppTemplates/MoSync_Reload_Windows/ReloadLauncher.bat
@@ -1,5 +1,4 @@
 cd server
 start bin\win\node.exe node_modules\weinre\weinre --boundHost -all-
-start bin\win\node.exe aardwolf\app.js
 start bin\win\node.exe main.js
 cd ..

--- a/ReloadServer/aardwolf/app.js
+++ b/ReloadServer/aardwolf/app.js
@@ -23,6 +23,10 @@ if (argv['white-list']){ config.whiteList = argv['white-list'].split(','); }
 
 try {
     /* Makes sure the path exists and gets rid of any trailing slashes. */
+    if( !fs.existsSync(config.fileServerBaseDir)) {
+    	//create it 
+    	fs.mkdirSync(config.fileServerBaseDir);
+    }
     config.fileServerBaseDir = fs.realpathSync(config.fileServerBaseDir);
 } catch (e) {
     console.error(e.message);


### PR DESCRIPTION
- Fixed the aardwolf crash due to non existing directory "samples"
    that temporary debugged files are stored into it.
  - Removed temporarily added aardwolf start in the launcher script
    (Aardwolf debugger now starts from reload server)
